### PR TITLE
add sys/types.h for ssize_t

### DIFF
--- a/libsel4utils/include/sel4utils/serial_server/client.h
+++ b/libsel4utils/include/sel4utils/serial_server/client.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <sys/types.h>
 #include <stdint.h>
 
 #include <sel4/sel4.h>


### PR DESCRIPTION
the libmuslc.git repository doesn't apparently define ssize_t unless sys/types is included,
or some posix specific define is present.