### PR TITLE
Fixed clang warnings

### DIFF
--- a/libsel4platsupport/plat_include/am335x/sel4platsupport/plat/beaglebone.h
+++ b/libsel4platsupport/plat_include/am335x/sel4platsupport/plat/beaglebone.h
@@ -40,7 +40,7 @@
 */
 
 
-#ifndef _BEALGEBONE_H_
+#ifndef _BEAGLEBONE_H_
 #define _BEAGLEBONE_H_
 
 #ifdef __cplusplus

--- a/libsel4utils/include/sel4utils/sel4_zf_logif.h
+++ b/libsel4utils/include/sel4utils/sel4_zf_logif.h
@@ -30,15 +30,15 @@
  */
 
 #define ZF_LOGD_IF(cond, fmt, ...) \
-	if ((cond)) { ZF_LOGD("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
+	if (cond) { ZF_LOGD("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
 #define ZF_LOGI_IF(cond, fmt, ...) \
-	if ((cond)) { ZF_LOGI("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
+	if (cond) { ZF_LOGI("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
 #define ZF_LOGW_IF(cond, fmt, ...) \
-	if ((cond)) { ZF_LOGW("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
+	if (cond) { ZF_LOGW("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
 #define ZF_LOGE_IF(cond, fmt, ...) \
-	if ((cond)) { ZF_LOGE("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
+	if (cond) { ZF_LOGE("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
 #define ZF_LOGF_IF(cond, fmt, ...) \
-	if ((cond)) { ZF_LOGF("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
+	if (cond) { ZF_LOGF("[Cond failed: %s]\n\t" fmt, #cond, ## __VA_ARGS__); }
 
 #define ZF_LOGD_IFERR(err, fmt, ...) \
 	if ((err) != seL4_NoError) \

--- a/libsel4vka/include/vka/object.h
+++ b/libsel4vka/include/vka/object.h
@@ -106,9 +106,9 @@ vka_alloc_object_leaky(vka_t *vka, seL4_Word type, seL4_Word size_bits)
 static inline void
 vka_free_object(vka_t *vka, vka_object_t *object)
 {
-    cspacepath_t path = {0};
-
+    cspacepath_t path;
     vka_cspace_make_path(vka, object->cptr, &path);
+
     if (path.capPtr == 0) {
         ZF_LOGE("Failed to create cspace path to object");
         return;

--- a/libsel4vmm/src/vmm/vmm.c
+++ b/libsel4vmm/src/vmm/vmm.c
@@ -269,7 +269,7 @@ seL4_CPtr vmm_create_async_event_notification_cap(vmm_t *vmm, seL4_Word badge) {
     seL4_CPtr ntfn = vmm->plat_callbacks.get_async_event_notification();
 
     // path to notification cap slot
-    cspacepath_t ntfn_path = {};
+    cspacepath_t ntfn_path;
     vka_cspace_make_path(&vmm->vka, ntfn, &ntfn_path);
 
     // allocate slot to store copy


### PR DESCRIPTION
make compile-all passes except for kzm_simulation_debug_xml_defconfig which also fails on my machine without this patch. All tests pass when running 'make simulate-x86_64' and when running the tests on a BeagleBone Black using config bbone_black_debug_xml_defconfig