### PR TITLE
Add actual config to libsel4sync Kconfig

### DIFF
--- a/libsel4sync/Kconfig
+++ b/libsel4sync/Kconfig
@@ -18,3 +18,6 @@ config LIB_SEL4_SYNC
     default y
     help
         Synchronisation library for seL4
+
+config HAVE_LIB_SEL4_SYNC
+    bool


### PR DESCRIPTION
Without this no other entry can depend on HAVE_LIB_SEL4_SYNC.