### PR TITLE
Zcu102 7.0.0

### DIFF
--- a/libsel4platsupport/plat_include/zynqmp/sel4platsupport/plat/serial.h
+++ b/libsel4platsupport/plat_include/zynqmp/sel4platsupport/plat/serial.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017, DornerWorks
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_DORNERWORKS_BSD)
+ */
+/*
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ */
+#pragma once
+
+#include <platsupport/plat/serial.h>
+
+#define DEFAULT_SERIAL_PADDR UART0_PADDR
+#define DEFAULT_SERIAL_INTERRUPT UART0_IRQ
+


### PR DESCRIPTION
This pull request adds AARCH32 and AARCH64 support for the Xilinx Zynq UltraScale+ MPSoC. Tested on the ZCU102 development board.