### PR TITLE
Fix for aarch64 crt0 in libsel4platsupport.

### DIFF
--- a/libsel4platsupport/src/sel4_arch/aarch64/crt0.S
+++ b/libsel4platsupport/src/sel4_arch/aarch64/crt0.S
@@ -23,7 +23,7 @@
 _start:
     /* Setup a stack for ourselves. */
     ldr     x19, =_stack_top
-    mov     sp, x10
+    mov     sp, x19
 
     /* Setup bootinfo. The pointer to the bootinfo struct starts in 'r0'. */
     bl      seL4_InitBootInfo


### PR DESCRIPTION
Move the contents of the correct register to the stack pointer.

Signed-off-by: Robbie VanVossen <robert.vanvossen@dornerworks.com>