### PR TITLE
Added missing constants and functions for Beaglebone Black

### DIFF
--- a/libsel4platsupport/plat_include/am335x/sel4platsupport/plat/cpsw.h
+++ b/libsel4platsupport/plat_include/am335x/sel4platsupport/plat/cpsw.h
@@ -61,6 +61,9 @@ extern "C" {
 #define CPSW_SLIVER_NON_GIG_FULL_DUPLEX        CPSW_SL_MACCONTROL_FULLDUPLEX
 #define CPSW_SLIVER_NON_GIG_HALF_DUPLEX        (0x00u)
 #define CPSW_SLIVER_GIG_FULL_DUPLEX            CPSW_SL_MACCONTROL_GIG
+#define CPSW_SLIVER_INBAND                     CPSW_SL_MACCONTROL_EXT_EN
+#define PHY_FULL_DUPLEX                        (0x0100)
+
 
     /*
     ** Macros which can be used as 'statFlag' to the API CPSWSlMACStatusGet

--- a/libsel4platsupport/src/plat/am335x/phy.c
+++ b/libsel4platsupport/src/plat/am335x/phy.c
@@ -342,4 +342,41 @@ unsigned int PhyLinkStatusGet(unsigned int mdioBaseAddr,
     return FALSE;
 }
 
+
+/* The next two functions were copied from 'bb-sel4' project at:
+ *    https://github.com/juli1/bb-sel4
+ * In particular, they were taken from:
+ *    https://github.com/juli1/bb-sel4/blob/701e87f4d4a403d3b0c02326d42e8580a7ff4b7f/bb-eth/components/ConsumerThreadImpl/src/phy.c
+ */
+unsigned int PhyReset(unsigned int mdioBaseAddr, unsigned int phyAddr)
+{
+    unsigned short data;
+
+    data = PHY_SOFTRESET;
+
+    /* Reset the phy */
+    MDIOPhyRegWrite(mdioBaseAddr, phyAddr, PHY_BCR, data);
+
+    /* wait till the reset bit is auto cleared */
+    while(data & PHY_SOFTRESET)
+    {
+        /* Read the reset */
+        if(MDIOPhyRegRead(mdioBaseAddr, phyAddr, PHY_BCR, &data) != TRUE)
+        {
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+unsigned int PhyConfigure(unsigned int mdioBaseAddr, unsigned int phyAddr,
+                              unsigned short speed, unsigned short duplexMode)
+{
+    /* Set the configurations */
+    MDIOPhyRegWrite(mdioBaseAddr, phyAddr, PHY_BCR, (speed | duplexMode));
+
+        return TRUE;
+}
+
 /**************************** End Of File ***********************************/


### PR DESCRIPTION
The missing constants and functions are used in util_libs/libethdrivers and are needed in order to build for Beaglebone black.
Now, even after those missing macros & functions I still don't have the lwip+ethdriver working on BBB (yet), but at least I get it to build.
