### PR TITLE
libsel4test: guard call to seL4_BenchmarkResetLog() by CONFIG_ENABLE_…

### DIFF
--- a/libsel4test/src/testutil.c
+++ b/libsel4test/src/testutil.c
@@ -106,7 +106,9 @@ void sel4test_reset(void)
     current_test_result = SUCCESS;
 
     if (config_set(CONFIG_ENABLE_BENCHMARKS)) {
+#ifdef CONFIG_ENABLE_BENCHMARKS
         seL4_BenchmarkResetLog();
+#endif /* CONFIG_ENABLE_BENCHMARKS */
     }
 }
 


### PR DESCRIPTION
…BENCHMARKS

Fix compilation failure about missing function seL4_BenchmarkResetLog(), which is defined only if CONFIG_ENABLE_BENCHMARKS is set.