### PR TITLE
libsel4simple-default: Don't assert return pointers

### DIFF
--- a/libsel4simple-default/src/libsel4simple-default.c
+++ b/libsel4simple-default/src/libsel4simple-default.c
@@ -128,7 +128,7 @@ int simple_default_untyped_count(void *data) {
 }
 
 seL4_CPtr simple_default_nth_untyped(void *data, int n, size_t *size_bits, uintptr_t *paddr, bool *device) {
-    assert(data && size_bits && paddr);
+    assert(data);
 
     seL4_BootInfo *bi = data;
 


### PR DESCRIPTION
It is valid for these pointers to be NULL. They are checked anyway, so
remove them from the assert.