### PR TITLE
Use constructor to initialise libc

### DIFF
--- a/libsel4muslcsys/CMakeLists.txt
+++ b/libsel4muslcsys/CMakeLists.txt
@@ -79,7 +79,7 @@ target_include_directories(sel4muslcsys PUBLIC include)
 target_link_libraries(
     sel4muslcsys
     PUBLIC
-    # These quotes are needed to prevent cmake splitting these arguments
+        # These quotes are needed to prevent cmake splitting these arguments
         "-Wl,-u -Wl,__vsyscall_ptr"
         muslc
         sel4

--- a/libsel4muslcsys/CMakeLists.txt
+++ b/libsel4muslcsys/CMakeLists.txt
@@ -73,6 +73,8 @@ set(HighestSyscall 400)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=700 -DMUSLC_HIGHEST_SYSCALL=${HighestSyscall}")
 
 add_library(sel4muslcsys STATIC EXCLUDE_FROM_ALL ${deps})
+# Force the muslcsys_init_muslc constructor to be included in dependants
+target_link_options(sel4muslcsys BEFORE INTERFACE "-Wl,-umuslcsys_init_muslc")
 target_include_directories(sel4muslcsys PUBLIC include)
 target_link_libraries(
     sel4muslcsys


### PR DESCRIPTION
This initialises the C standard library using a constructor executed by the sel4runtime.