### PR TITLE
libsel4bench: include autoconf.h

### DIFF
--- a/libsel4bench/include/sel4bench/kernel_logging.h
+++ b/libsel4bench/include/sel4bench/kernel_logging.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <autoconf.h>
 #include <sel4/config.h>
 #include <sel4/types.h>
 #include <sel4/arch/constants.h>


### PR DESCRIPTION
I'm getting this error
```
In file included from libsel4/autoconf/autoconf.h:4,
                 from .../kernel/libsel4/include/sel4/macros.h:9,
                 from .../kernel/libsel4/include/sel4/types.h:13,
                 from .../sel4_libs/libsel4bench/include/sel4bench/kernel_logging.h:16,
                 from .../sel4_libs/libsel4bench/src/kernel_logging.c:13:
kernel/gen_config/kernel/gen_config.h:24: warning: "CONFIG_ROOT_CNODE_SIZE_BITS" redefined
 #define CONFIG_ROOT_CNODE_SIZE_BITS 15
 
In file included from .../sel4_libs/libsel4bench/include/sel4bench/kernel_logging.h:15,
                 from .../sel4_libs/libsel4bench/src/kernel_logging.c:13:
.../kernel/libsel4/include/sel4/config.h:17: note: this is the location of the previous definition
 #define CONFIG_ROOT_CNODE_SIZE_BITS 12
``` 

and a similar one for `CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS` and `CONFIG_NUM_DOMAINS`. The explanation is, that in kernel commit https://github.com/seL4/seL4/commit/1ce721b418f13e7430d379461c59b80322fc6daf the file `sel4/config.h` was extended to make the kernel configuration available to user space. However, it will include `autoconf.h` only if `HAVE_AUTOCONF` is defined and provide a fixed default configuration otherwise. We don't define `HAVE_AUTOCONF` anywhere, but include `autoconf.h` unconditionally instead everywhere, which leads to conflicting defines if this include is forgotten. Thus we add the missing include `autoconf.h` here before including `sel4/config.h` then.

We could also define `HAVE_AUTOCONF`, but I wonder if this should be considered deprecated and get removed everywhere eventually. We no longer use autoconf and CMake just mimics it keep compatibility. I wonder if there is any need for all the compatibility layers left nowaday and the change in `sel4/config.h` are another step away form this actually. If `HAVE_AUTOCONF` gets fully removed, all project could just include `sel4/config.h` instead of the attic `autoconf.h`.

Note that we could also avoid this PR if we change `sel4/config.h` and replace 
```
#ifdef HAVE_AUTOCONF
#include <autoconf.h>
#endif
```
with simply 
```
#include <autoconf.h>
```
but I wonder which additional side effects this has in other modules. So merging this PR here might be the quicker way to avoid the current problem before trying to solve this in a more general way.