### PR TITLE
avoid build warning if CONFIG_IOMMU is not defined

### DIFF
--- a/libsel4vspace/src/arch/arm/mapping.c
+++ b/libsel4vspace/src/arch/arm/mapping.c
@@ -7,7 +7,8 @@
 #include <autoconf.h>
 #include <vspace/mapping.h>
 
-static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root, seL4_Word vaddr, UNUSED seL4_Word attr)
+static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root,
+                                seL4_Word vaddr, UNUSED seL4_Word attr)
 {
 #ifdef CONFIG_TK1_SMMU
     return seL4_ARM_IOPageTable_Map(cap, iospace_root, vaddr);

--- a/libsel4vspace/src/arch/arm/mapping.c
+++ b/libsel4vspace/src/arch/arm/mapping.c
@@ -7,13 +7,13 @@
 #include <autoconf.h>
 #include <vspace/mapping.h>
 
+#ifdef CONFIG_TK1_SMMU
 static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root,
                                 seL4_Word vaddr, UNUSED seL4_Word attr)
 {
-#ifdef CONFIG_TK1_SMMU
     return seL4_ARM_IOPageTable_Map(cap, iospace_root, vaddr);
-#endif
 }
+#endif /* CONFIG_TK1_SMMU */
 
 int vspace_get_iospace_map_obj(UNUSED seL4_Word failed_bits, vspace_map_obj_t *obj)
 {

--- a/libsel4vspace/src/arch/x86/mapping.c
+++ b/libsel4vspace/src/arch/x86/mapping.c
@@ -8,13 +8,13 @@
 #include <vspace/mapping.h>
 #include <sel4/arch/mapping.h>
 
+#ifdef CONFIG_IOMMU
 static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root,
                                 seL4_Word vaddr, UNUSED seL4_Word attr)
 {
-#ifdef CONFIG_IOMMU
     return seL4_X86_IOPageTable_Map(cap, iospace_root, vaddr);
-#endif
 }
+#endif /* CONFIG_TK1_SMMU */
 
 int vspace_get_iospace_map_obj(UNUSED seL4_Word failed_bits, vspace_map_obj_t *obj)
 {

--- a/libsel4vspace/src/arch/x86/mapping.c
+++ b/libsel4vspace/src/arch/x86/mapping.c
@@ -8,7 +8,8 @@
 #include <vspace/mapping.h>
 #include <sel4/arch/mapping.h>
 
-static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root, seL4_Word vaddr, UNUSED seL4_Word attr)
+static seL4_Error vspace_map_io(seL4_CPtr cap, seL4_CPtr iospace_root,
+                                seL4_Word vaddr, UNUSED seL4_Word attr)
 {
 #ifdef CONFIG_IOMMU
     return seL4_X86_IOPageTable_Map(cap, iospace_root, vaddr);


### PR DESCRIPTION
The function `vspace_map_io()` is only used when `CONFIG_IOMMU` is defined, thus the clang build warning "control reaches end of non-void function [-Wreturn-type]" can be avoided easily when this function only exists when it is needed.
