### PR TITLE
Add cpu/events.h header for Cortex-A35

### DIFF
--- a/libsel4bench/arch_include/arm/cpu/cortex-a35/sel4bench/cpu/events.h
+++ b/libsel4bench/arch_include/arm/cpu/cortex-a35/sel4bench/cpu/events.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
+ * Values from Cortex-A35 TRM. Table C2-3.
+ */
+#pragma once
+#define SEL4BENCH_EVENT_BUS_ACCESS_LD         0x60
+#define SEL4BENCH_EVENT_BUS_ACCESS_ST         0x61
+#define SEL4BENCH_EVENT_BR_INDIRECT_SPEC      0x7A
+#define SEL4BENCH_EVENT_EXC_IRQ               0x86
+#define SEL4BENCH_EVENT_EXC_FIQ               0x87


### PR DESCRIPTION
This closes #28 

Signed-off-by: Ben Leslie <benno@brkawy.com>