### PR TITLE
Remove assert in libsel4muslcsys/src/sys_io.c::sys_close()

### DIFF
--- a/libsel4muslcsys/src/sys_io.c
+++ b/libsel4muslcsys/src/sys_io.c
@@ -253,8 +253,6 @@ long sys_close(va_list ap)
 
     if (fds->filetype == FILE_TYPE_CPIO) {
         free(fds->data);
-    } else {
-        assert(!"not implemented");
     }
     add_free_fd(fd);
     return 0;


### PR DESCRIPTION
There we assert that the only file type admitted is FILE_TYPE_CPIO,
however libsel4camkes implements support to FILE_TYPE_SOCKET.

Signed-off-by: Carmelo Pintaudi <carmelo.pintaudi@hensoldt-cyber.de>