### PR TITLE
trivial: Fixup compiler warnings

### DIFF
--- a/libsel4debug/src/caps.c
+++ b/libsel4debug/src/caps.c
@@ -16,6 +16,6 @@ void debug_cap_identify(seL4_CPtr cap)
     int type = seL4_DebugCapIdentify(cap);
     printf("Cap %"SEL4_PRIu_word" has type %d\n", cap, type);
 #else
-    printf("DEBUG_BUILD not set, can't get type of cap %d", cap);
+    printf("DEBUG_BUILD not set, can't get type of cap %"SEL4_PRIu_word"\n", cap);
 #endif
 }

--- a/libsel4serialserver/src/server.c
+++ b/libsel4serialserver/src/server.c
@@ -257,7 +257,7 @@ seL4_Error serial_server_func_connect(seL4_MessageInfo_t tag,
                 "%dB.",
                 client_badge_value, client_shmem_size,
                 get_serial_server()->shmem_max_size);
-        return SERIAL_SERVER_ERROR_SHMEM_TOO_LARGE;
+        return (seL4_Error) SERIAL_SERVER_ERROR_SHMEM_TOO_LARGE;
     }
 
     if (seL4_MessageInfo_get_extraCaps(tag) != client_shmem_n_pages) {


### PR DESCRIPTION
- Use seL4_Word printf modifier for seL4_CPtr type.
- Cast return value to (seL4_Error) as the API defines custom error
  codes starting after the seL4_Error enum finishes.

Signed-off-by: Kent McLeod <kent@kry10.com>