### PR TITLE
RFC: AArch64: remove VSpace object types, seL4_ARM_PageDirectory and seL4_ARM_PageUpperDirectory

### DIFF
--- a/libsel4allocman/sel4_arch/aarch64/allocman/sel4_arch/reservation.h
+++ b/libsel4allocman/sel4_arch/aarch64/allocman/sel4_arch/reservation.h
@@ -9,7 +9,6 @@
 #include <allocman/allocman.h>
 
 static inline void allocman_sel4_arch_configure_reservations(allocman_t *alloc) {
-    allocman_configure_utspace_reserve(alloc, (struct allocman_utspace_chunk) {vka_get_object_size(seL4_ARM_PageDirectoryObject, 0), seL4_ARM_PageDirectoryObject, 1});
-    allocman_configure_utspace_reserve(alloc, (struct allocman_utspace_chunk) {vka_get_object_size(seL4_ARM_PageUpperDirectoryObject, 0), seL4_ARM_PageUpperDirectoryObject, 1});
+    allocman_configure_utspace_reserve(alloc, (struct allocman_utspace_chunk) {vka_get_object_size(seL4_ARCH_PageTableObject, 0), seL4_ARCH_PageTableObject, 3});
 }
 

--- a/libsel4allocman/src/bootstrap.c
+++ b/libsel4allocman/src/bootstrap.c
@@ -1263,7 +1263,9 @@ void bootstrap_configure_virtual_pool(allocman_t *alloc, void *vstart, size_t vs
     /* assume we are using 4k pages. maybe this should be a Kconfig option at some point?
      * we ignore any errors */
     allocman_configure_utspace_reserve(alloc, (struct allocman_utspace_chunk) {vka_get_object_size(seL4_ARCH_4KPage, 0), seL4_ARCH_4KPage, 3});
+#ifndef CONFIG_ARCH_AARCH64
     allocman_configure_utspace_reserve(alloc, (struct allocman_utspace_chunk) {vka_get_object_size(seL4_ARCH_PageTableObject, 0), seL4_ARCH_PageTableObject, 1});
+#endif
     allocman_sel4_arch_configure_reservations(alloc);
     mspace_dual_pool_attach_virtual(
             (mspace_dual_pool_t*)alloc->mspace.mspace,

--- a/libsel4vka/arch_include/arm/vka/arch/object.h
+++ b/libsel4vka/arch_include/arm/vka/arch/object.h
@@ -44,8 +44,6 @@ vka_arch_get_object_size(seL4_Word objectType)
         return seL4_LargePageBits;
     case seL4_ARM_PageTableObject:
         return seL4_PageTableBits;
-    case seL4_ARM_PageDirectoryObject:
-        return seL4_PageDirBits;
     case seL4_ARM_VCPUObject:
         return seL4_ARM_VCPUBits;
 #ifdef CONFIG_TK1_SMMU

--- a/libsel4vka/sel4_arch_include/aarch32/vka/sel4_arch/object.h
+++ b/libsel4vka/sel4_arch_include/aarch32/vka/sel4_arch/object.h
@@ -28,6 +28,8 @@ static inline unsigned long vka_arm_mode_get_object_size(seL4_Word objectType)
         return seL4_SectionBits;
     case seL4_ARM_SuperSectionObject:
         return seL4_SuperSectionBits;
+    case seL4_ARM_PageDirectoryObject:
+        return seL4_PageDirBits;
     default:
         /* Unknown object type. */
         ZF_LOGE("Unknown object type");

--- a/libsel4vka/sel4_arch_include/aarch64/vka/sel4_arch/kobject_t.h
+++ b/libsel4vka/sel4_arch_include/aarch64/vka/sel4_arch/kobject_t.h
@@ -56,7 +56,12 @@ static inline seL4_Word arm_mode_kobject_get_type(kobject_t type, seL4_Word obje
             return -1;
         }
     case KOBJECT_PAGE_GLOBAL_DIRECTORY:
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined (CONFIG_ARM_PA_SIZE_BITS_40)
+        /* This object type is invalid under this configuration. */
+        return -1;
+#else
         return seL4_ARM_PageGlobalDirectoryObject;
+#endif
     case KOBJECT_PAGE_UPPER_DIRECTORY:
         return seL4_ARM_PageUpperDirectoryObject;
     default:

--- a/libsel4vka/sel4_arch_include/aarch64/vka/sel4_arch/object.h
+++ b/libsel4vka/sel4_arch_include/aarch64/vka/sel4_arch/object.h
@@ -42,10 +42,8 @@ vka_arm_mode_get_object_size(seL4_Word objectType)
     switch (objectType) {
     case seL4_ARM_HugePageObject:
         return seL4_HugePageBits;
-    case seL4_ARM_PageGlobalDirectoryObject:
-        return seL4_PGDBits;
-    case seL4_ARM_PageUpperDirectoryObject:
-        return seL4_PUDBits;
+    case seL4_ARM_VSpaceObject:
+        return seL4_VSpaceBits;
     default:
         /* Unknown object type. */
         ZF_LOGE("Unknown object type");


### PR DESCRIPTION
These changes are required to support the proposed changes in https://github.com/seL4/seL4/pull/801.

Test with: https://github.com/seL4/seL4/pull/801
Test with: https://github.com/seL4/sel4test/pull/100