### PR TITLE
libsel4utils: remove obsolete includes

### DIFF
--- a/libsel4utils/arch_include/riscv/sel4utils/arch/util.h
+++ b/libsel4utils/arch_include/riscv/sel4utils/arch/util.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 #include <sel4/sel4.h>
-#include <sel4/arch/pfIPC.h>
-#include <sel4/arch/exIPC.h>
 
 #define EXCEPT_IPC_SYS_MR_IP EXCEPT_IPC_SYS_MR_RIP
 #define ARCH_SYSCALL_INSTRUCTION_SIZE 4

--- a/libsel4utils/arch_include/riscv/sel4utils/arch/util.h
+++ b/libsel4utils/arch_include/riscv/sel4utils/arch/util.h
@@ -13,34 +13,30 @@
 #define EXCEPT_IPC_SYS_MR_IP EXCEPT_IPC_SYS_MR_RIP
 #define ARCH_SYSCALL_INSTRUCTION_SIZE 4
 
-static inline int
-sel4utils_is_read_fault(void)
+static inline int sel4utils_is_read_fault(void)
 {
     seL4_Word fsr = seL4_GetMR(seL4_VMFault_FSR);
     return (fsr == 1 || fsr == 2 || fsr == 5);
 }
 
-static inline void
-sel4utils_set_instruction_pointer(seL4_UserContext *regs, seL4_Word value)
+static inline void sel4utils_set_instruction_pointer(seL4_UserContext *regs,
+                                                     seL4_Word value)
 {
     regs->pc = value;
 }
 
-static inline seL4_Word
-sel4utils_get_instruction_pointer(seL4_UserContext regs)
+static inline seL4_Word sel4utils_get_instruction_pointer(seL4_UserContext regs)
 {
     return regs.pc;
 }
 
-static inline seL4_Word
-sel4utils_get_sp(seL4_UserContext regs)
+static inline seL4_Word sel4utils_get_sp(seL4_UserContext regs)
 {
     return regs.sp;
 }
 
-static inline void
-sel4utils_set_stack_pointer(seL4_UserContext *regs, seL4_Word value)
+static inline void sel4utils_set_stack_pointer(seL4_UserContext *regs,
+                                               seL4_Word value)
 {
     regs->sp = value;
 }
-

--- a/libsel4utils/sel4_arch_include/x86_64/sel4utils/sel4_arch/util.h
+++ b/libsel4utils/sel4_arch_include/x86_64/sel4utils/sel4_arch/util.h
@@ -12,27 +12,24 @@
 
 #define EXCEPT_IPC_SYS_MR_IP EXCEPT_IPC_SYS_MR_RIP
 
-static inline void
-sel4utils_set_instruction_pointer(seL4_UserContext *regs, seL4_Word value)
+static inline void sel4utils_set_instruction_pointer(seL4_UserContext *regs,
+                                                     seL4_Word value)
 {
     regs->rip = value;
 }
 
-static inline seL4_Word
-sel4utils_get_instruction_pointer(seL4_UserContext regs)
+static inline seL4_Word sel4utils_get_instruction_pointer(seL4_UserContext regs)
 {
     return regs.rip;
 }
 
-static inline seL4_Word
-sel4utils_get_sp(seL4_UserContext regs)
+static inline seL4_Word sel4utils_get_sp(seL4_UserContext regs)
 {
     return regs.rsp;
 }
 
-static inline void
-sel4utils_set_stack_pointer(seL4_UserContext *regs, seL4_Word value)
+static inline void sel4utils_set_stack_pointer(seL4_UserContext *regs,
+                                               seL4_Word value)
 {
     regs->rsp = value;
 }
-

--- a/libsel4utils/sel4_arch_include/x86_64/sel4utils/sel4_arch/util.h
+++ b/libsel4utils/sel4_arch_include/x86_64/sel4utils/sel4_arch/util.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 #include <sel4/sel4.h>
-#include <sel4/arch/pfIPC.h>
-#include <sel4/arch/exIPC.h>
 
 #define EXCEPT_IPC_SYS_MR_IP EXCEPT_IPC_SYS_MR_RIP
 


### PR DESCRIPTION
This include file is deprecated since 2016, and it seems there's nothing in there that is needed. Removing the reference here is a preparation to delete this file from the kernel includes completely, see https://github.com/seL4/seL4/issues/813