### PR TITLE
libsel4muslcsys: use const for CPIO data

### DIFF
--- a/libsel4muslcsys/include/muslcsys/io.h
+++ b/libsel4muslcsys/include/muslcsys/io.h
@@ -20,7 +20,7 @@
 #define FILE_TYPE_CPIO 0
 
 typedef struct cpio_file_data {
-    char *start;
+    char const *start;
     uint32_t size;
     off_t current;
 } cpio_file_data_t;
@@ -49,7 +49,10 @@ muslcsys_fd_t *
 get_fd_struct(int fd);
 
 /* install a cpio interface to use with open */
-typedef void *(*muslcsys_cpio_get_file_fn_t)(void *cpio_symbol, unsigned long len,
-                                             const char *name, unsigned long *size);
-void muslcsys_install_cpio_interface(void *cpio_symbol, unsigned long cpio_len,
+typedef void const *(*muslcsys_cpio_get_file_fn_t)(void const *cpio_symbol,
+                                                   unsigned long len,
+                                                   char const *name,
+                                                   unsigned long *size);
+void muslcsys_install_cpio_interface(void const *cpio_symbol,
+                                     unsigned long cpio_len,
                                      muslcsys_cpio_get_file_fn_t fn);

--- a/libsel4muslcsys/src/sys_io.c
+++ b/libsel4muslcsys/src/sys_io.c
@@ -35,7 +35,7 @@
 /* this implementation does not allow users to close STDOUT or STDERR, so they can't be freed */
 #define FREE_FD_TABLE_SIZE(x) (sizeof(int) * ((x) - FIRST_USER_FD))
 
-static void *cpio_archive_symbol;
+static void const *cpio_archive_symbol;
 static unsigned long cpio_archive_len;
 static muslcsys_cpio_get_file_fn_t cpio_get_file_impl;
 
@@ -181,7 +181,7 @@ static long sys_open_impl(const char *pathname, int flags, mode_t mode)
     }
     /* as we do not support create, ignore the mode */
     long unsigned int size;
-    char *file = NULL;
+    char const *file = NULL;
     if (cpio_get_file_impl && cpio_archive_symbol) {
         file = cpio_get_file_impl(cpio_archive_symbol, cpio_archive_len, pathname, &size);
         if (!file && strncmp(pathname, "./", 2) == 0) {
@@ -530,7 +530,7 @@ long sys_access(va_list ap)
     return -EACCES;
 }
 
-void muslcsys_install_cpio_interface(void *cpio_symbol, unsigned long cpio_len,
+void muslcsys_install_cpio_interface(void const *cpio_symbol, unsigned long cpio_len,
                                      muslcsys_cpio_get_file_fn_t fn)
 {
     cpio_archive_symbol = cpio_symbol;


### PR DESCRIPTION
CPIO data cannot be modified, it's basically ROM. The CPIO APIs have been changed some time back to use the const qualifier to properly reflect this. Add the const qualifier here also to avoid compiler warnings.

For example, this is the compiler warning with the FileServer from the VM examples:
```
.../libs/sel4_global_components/components/FileServer/src/server.c: In function ‘pre_init’:
.../libs/sel4_global_components/components/FileServer/src/server.c:34:63: warning: passing argument 3 of ‘muslcsys_install_cpio_interface’ from incompatible pointer type [-Wincompatible-pointer-types]
     muslcsys_install_cpio_interface(_cpio_archive, cpio_size, cpio_get_file);
                                                               ^~~~~~~~~~~~~
In file included from .../libs/sel4_global_components/components/FileServer/src/server.c:13:
.../libs/sel4_libs/libsel4muslcsys/include/muslcsys/io.h:55:66: note: expected ‘muslcsys_cpio_get_file_fn_t’ {aka ‘void * (*)(void *, long unsigned int,  const char *, long unsigned int *)’} but argument is of type ‘const void * (*)(const void *, long unsigned int,  const char *, long unsigned int *)’
                                      muslcsys_cpio_get_file_fn_t fn);
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```