### PR TITLE
libsel4muslcsys,mmap: Assert page aligned value

### DIFF
--- a/libsel4muslcsys/src/sys_morecore.c
+++ b/libsel4muslcsys/src/sys_morecore.c
@@ -195,6 +195,7 @@ static long sys_mmap_impl_static(void *addr, size_t length, int prot, int flags,
             return -ENOMEM;
         }
         morecore_top = base;
+        ZF_LOGF_IF((base % 0x1000) != 0, "return address: 0x%"PRIxPTR" requires alignment: 0x%x ", base, 0x1000);
         return base;
     }
     assert(!"not implemented");
@@ -212,6 +213,8 @@ static long sys_mmap_impl_dynamic(void *addr, size_t length, int prot, int flags
         /* determine how many pages we need */
         uint32_t pages = BYTES_TO_4K_PAGES(length);
         void *ret = vspace_new_pages(muslc_this_vspace, seL4_AllRights, pages, seL4_PageBits);
+        ZF_LOGF_IF((((uintptr_t)ret) % 0x1000) != 0, "return address: 0x%"PRIxPTR" requires alignment: 0x%x ", (uintptr_t)ret,
+                   0x1000);
         return (long)ret;
     }
     assert(!"not implemented");


### PR DESCRIPTION
mmap creates mappings in multiples of the page size which is always at
least 4096. Assert that the return value is at least page size aligned.
Callers of mmap are allowed to assume that the memory returned is 4k
aligned and this can lead to subtle errors if non-aligned values are
returned.