### PR TITLE
sel4muslcsys: Allocate aligned addr in static mmap

### DIFF
--- a/libsel4muslcsys/src/sys_morecore.c
+++ b/libsel4muslcsys/src/sys_morecore.c
@@ -189,8 +189,13 @@ static long sys_mmap_impl_static(void *addr, size_t length, int prot, int flags,
     if (flags & MAP_ANONYMOUS) {
         /* ensure the morecore region is initialized */
         init_morecore_region();
+
+        /* Calculate number of pages needed */
+        uintptr_t pages = BYTES_TO_4K_PAGES(length);
+        uintptr_t adjusted_length = pages * PAGE_SIZE_4K;
+
         /* Steal from the top */
-        uintptr_t base = morecore_top - length;
+        uintptr_t base = morecore_top - adjusted_length;
         if (base < morecore_base) {
             return -ENOMEM;
         }


### PR DESCRIPTION
It's invalid to return regions that are not page aligned. We round
lengths up to the nearest page size. munmap and mremmap are not
supported with static mmap and so we don't need to track this rounding
difference anywhere.

Signed-off-by: Kent McLeod <kent@kry10.com>