### PR TITLE
mcs: add handler params to TCB configure functions

### DIFF
--- a/libsel4allocman/src/bootstrap.c
+++ b/libsel4allocman/src/bootstrap.c
@@ -455,7 +455,7 @@ static int bootstrap_new_1level_cspace(bootstrap_info_t *bs, int size) {
         return 1;
     }
     /* now we can call set space */
-    error = api_tcb_set_space(bs->tcb.capPtr, 0,
+    error = api_tcb_set_space(bs->tcb.capPtr, 0, seL4_NilData, seL4_NoRights,
                 node.capPtr,
                 api_make_guard_skip_word(seL4_WordBits - size),
                 bs->pd.capPtr, seL4_NilData);
@@ -589,7 +589,7 @@ static int bootstrap_new_2level_cspace(bootstrap_info_t *bs, size_t l1size, size
         return 1;
     }
     /* now we can call set space */
-    error = api_tcb_set_space(bs->tcb.capPtr, 0,
+    error = api_tcb_set_space(bs->tcb.capPtr, 0, seL4_NilData, seL4_NoRights,
                 l1node.capPtr,
                 api_make_guard_skip_word(seL4_WordBits - l1size - l2size),
                 bs->pd.capPtr, seL4_NilData);

--- a/libsel4utils/include/sel4utils/mcs_api.h
+++ b/libsel4utils/include/sel4utils/mcs_api.h
@@ -93,18 +93,19 @@ static inline seL4_MessageInfo_t api_nbsend_wait(UNUSED seL4_CPtr send, UNUSED s
 #endif
 }
 
-static inline seL4_Error api_tcb_configure(seL4_CPtr tcb, seL4_CPtr ep, UNUSED seL4_CPtr timeout_ep,
-                                           UNUSED seL4_CPtr sc, seL4_CPtr cspace,
-                                           seL4_Word cdata, seL4_CPtr vspace, seL4_Word vdata,
+static inline seL4_Error api_tcb_configure(seL4_CPtr tcb, seL4_CPtr ep, UNUSED seL4_Word epdata,
+                                           UNUSED seL4_CapRights_t eprights, UNUSED seL4_CPtr timeout_ep,
+                                           UNUSED seL4_Word tfdata, UNUSED seL4_CapRights_t tfrights, UNUSED seL4_CPtr sc,
+                                           seL4_CPtr cspace, seL4_Word cdata, seL4_CPtr vspace, seL4_Word vdata,
                                            seL4_Word ipc_buffer_addr, seL4_CPtr ipc_buffer_cap)
 {
 #ifdef CONFIG_KERNEL_MCS
-    seL4_Error error = seL4_TCB_SetSpace(tcb, ep, cspace, cdata, vspace, vdata);
+    seL4_Error error = seL4_TCB_SetSpace(tcb, ep, epdata, eprights, cspace, cdata, vspace, vdata);
     if (!error) {
         error = seL4_TCB_SetIPCBuffer(tcb, ipc_buffer_addr, ipc_buffer_cap);
     }
     if (!error) {
-        error = seL4_TCB_SetTimeoutEndpoint(tcb, timeout_ep);
+        error = seL4_TCB_SetTimeoutEndpoint(tcb, timeout_ep, tfdata, tfrights);
     }
     if (!error && sc != seL4_CapNull) {
         error = seL4_SchedContext_Bind(sc, tcb);
@@ -117,21 +118,26 @@ static inline seL4_Error api_tcb_configure(seL4_CPtr tcb, seL4_CPtr ep, UNUSED s
 }
 
 static inline seL4_Error api_tcb_set_sched_params(seL4_CPtr tcb, seL4_CPtr auth, seL4_Word prio,
-                                                  seL4_Word mcp, UNUSED seL4_CPtr sc, UNUSED seL4_CPtr ep)
+                                                  seL4_Word mcp, UNUSED seL4_CPtr sc, UNUSED seL4_CPtr ep,
+                                                  UNUSED seL4_Word epdata, UNUSED seL4_CapRights_t eprights)
 {
 #ifdef CONFIG_KERNEL_MCS
-    return seL4_TCB_SetSchedParams(tcb, auth, mcp, prio, sc, ep);
+    return seL4_TCB_SetSchedParams(tcb, auth, mcp, prio, sc, ep, epdata, eprights);
 #else
     return seL4_TCB_SetSchedParams(tcb, auth, mcp, prio);
 #endif
 
 }
 
-static inline seL4_Error api_tcb_set_space(seL4_CPtr tcb, seL4_CPtr ep,
-                                           seL4_CPtr cspace,
+static inline seL4_Error api_tcb_set_space(seL4_CPtr tcb, seL4_CPtr ep, seL4_Word epdata,
+                                           seL4_CapRights_t eprights, seL4_CPtr cspace,
                                            seL4_Word cdata, seL4_CPtr vspace, seL4_Word vdata)
 {
+#ifdef CONFIG_KERNEL_MCS
+    return seL4_TCB_SetSpace(tcb, ep, epdata, eprights, cspace, cdata, vspace, vdata);
+#else
     return seL4_TCB_SetSpace(tcb, ep, cspace, cdata, vspace, vdata);
+#endif
 }
 
 static inline seL4_Error api_sc_bind(UNUSED seL4_CPtr sc, UNUSED seL4_CPtr tcb)

--- a/libsel4utils/src/thread.c
+++ b/libsel4utils/src/thread.c
@@ -99,8 +99,8 @@ int sel4utils_configure_thread_config(vka_t *vka, vspace_t *parent, vspace_t *al
         res->sched_context.cptr = config.sched_params.sched_context;
     }
     seL4_Word null_cap_data = seL4_NilData;
-    error = api_tcb_configure(res->tcb.cptr, config.fault_endpoint,
-                              seL4_CapNull,
+    error = api_tcb_configure(res->tcb.cptr, config.fault_endpoint, null_cap_data, seL4_NoRights,
+                              seL4_CapNull, null_cap_data, seL4_NoRights,
                               res->sched_context.cptr,
                               config.cspace,
                               config.cspace_root_data, vspace_get_root(alloc),


### PR DESCRIPTION
This makes it possible to set the badge and rights of the fault and timeout handler caps while configuring a TCB.