### PR TITLE
libsel4utils: use seL4_Time instead of uint64_t

### DIFF
--- a/libsel4utils/include/sel4utils/mcs_api.h
+++ b/libsel4utils/include/sel4utils/mcs_api.h
@@ -177,7 +177,7 @@ static inline seL4_SchedContext_Consumed_t api_sc_consumed(UNUSED seL4_CPtr sc)
 }
 
 static inline seL4_Error api_sched_ctrl_configure(UNUSED seL4_CPtr sched_ctrl, UNUSED seL4_CPtr sc,
-                                                  UNUSED uint64_t budget, UNUSED uint64_t period,
+                                                  UNUSED seL4_Time budget, UNUSED seL4_Time period,
                                                   UNUSED seL4_Word refills, UNUSED seL4_Word badge)
 {
     if (!config_set(CONFIG_KERNEL_MCS)) {

--- a/libsel4utils/include/sel4utils/process_config.h
+++ b/libsel4utils/include/sel4utils/process_config.h
@@ -184,8 +184,9 @@ static inline sel4utils_process_config_t process_config_default_simple(simple_t 
     config = process_config_create_fault_endpoint(config);
 
     if (config_set(CONFIG_KERNEL_MCS)) {
-        uint64_t timeslice = CONFIG_BOOT_THREAD_TIME_SLICE;
-        config.sched_params = sched_params_round_robin(config.sched_params, simple, 0, timeslice * US_IN_MS);
+        /* seL4_Time measures time in us, the config parameter uses ms. */
+        seL4_Time timeslice_us = CONFIG_BOOT_THREAD_TIME_SLICE * US_IN_MS;
+        config.sched_params = sched_params_round_robin(config.sched_params, simple, 0, timeslice_us);
     }
 
     return process_config_priority(config, prio);

--- a/libsel4utils/include/sel4utils/thread_config.h
+++ b/libsel4utils/include/sel4utils/thread_config.h
@@ -30,8 +30,8 @@ typedef struct sched_params {
     /* sel4 sched control cap for creating sc */
     seL4_CPtr sched_ctrl;
     /* scheduling parameters */
-    uint64_t period;
-    uint64_t budget;
+    seL4_Time period;
+    seL4_Time budget;
     seL4_Word extra_refills;
     seL4_Word badge;
     /* otherwise use this provided sc */
@@ -62,8 +62,8 @@ typedef struct sel4utils_thread_config {
 } sel4utils_thread_config_t;
 
 static inline sched_params_t sched_params_periodic(sched_params_t params, simple_t *simple, seL4_Word core,
-                                                   uint64_t period_us,
-                                                   uint64_t budget_us, seL4_Word extra_refills, seL4_Word badge)
+                                                   seL4_Time period_us,
+                                                   seL4_Time budget_us, seL4_Word extra_refills, seL4_Word badge)
 {
     if (!config_set(CONFIG_KERNEL_MCS)) {
         ZF_LOGW("Setting sched params on non-RT kernel will have no effect");
@@ -78,7 +78,7 @@ static inline sched_params_t sched_params_periodic(sched_params_t params, simple
 }
 
 static inline sched_params_t sched_params_round_robin(sched_params_t params, simple_t *simple, seL4_Word core,
-                                                      uint64_t timeslice_us)
+                                                      seL4_Time timeslice_us)
 {
     return sched_params_periodic(params, simple, core, timeslice_us, timeslice_us, 0, 0);
 }
@@ -175,8 +175,9 @@ static inline sel4utils_thread_config_t thread_config_default(simple_t *simple, 
     config = thread_config_fault_endpoint(config, fault_ep);
     config = thread_config_priority(config, prio);
     if (config_set(CONFIG_KERNEL_MCS)) {
-        uint64_t timeslice = CONFIG_BOOT_THREAD_TIME_SLICE;
-        config.sched_params = sched_params_round_robin(config.sched_params, simple, 0, timeslice * US_IN_MS);
+        /* seL4_Time measures time in us, the config parameter uses ms. */
+        seL4_Time timeslice_us = CONFIG_BOOT_THREAD_TIME_SLICE * US_IN_MS;
+        config.sched_params = sched_params_round_robin(config.sched_params, simple, 0, timeslice_us);
     }
     config = thread_config_create_reply(config);
     return config;


### PR DESCRIPTION
Use dedicated types instead of the generic uint64. Techically it does no make much difference, just improves the semantics a bit.

Test with: https://github.com/seL4/seL4/pull/922