### PR TITLE
muslcsys: implement dummy munmap call

### DIFF
--- a/libsel4muslcsys/src/sys_morecore.c
+++ b/libsel4muslcsys/src/sys_morecore.c
@@ -361,3 +361,10 @@ long sys_mmap2(va_list ap)
      * so this will not overflow */
     return sys_mmap_impl(addr, length, prot, flags, fd, offset * 4096);
 }
+
+long sys_munmap(va_list ap)
+{
+    ZF_LOGE("%s is unsupported. This may have been called due to a "
+            "large malloc'd region being free'd.", __func__);
+    return 0;
+}

--- a/libsel4muslcsys/src/sys_morecore.c
+++ b/libsel4muslcsys/src/sys_morecore.c
@@ -357,8 +357,8 @@ long sys_mmap2(va_list ap)
     int flags = va_arg(ap, int);
     int fd = va_arg(ap, int);
     off_t offset = va_arg(ap, off_t);
-    /* for now redirect to mmap. muslc always defines an off_t as being an int64
-     * so this will not overflow */
+    /* for now redirect to mmap. muslc always defines an off_t as being an int64 */
+    /* so this will not overflow */
     return sys_mmap_impl(addr, length, prot, flags, fd, offset * 4096);
 }
 

--- a/libsel4muslcsys/src/syscalls.h
+++ b/libsel4muslcsys/src/syscalls.h
@@ -32,8 +32,8 @@ long sys_access(va_list ap);
 long sys_brk(va_list ap);
 long sys_mmap2(va_list ap);
 long sys_mmap(va_list ap);
+long sys_munmap(va_list ap);
 long sys_mremap(va_list ap);
 long sys_write(va_list ap);
 long sys_writev(va_list ap);
 long sys_madvise(va_list ap);
-

--- a/libsel4muslcsys/src/vsyscall.c
+++ b/libsel4muslcsys/src/vsyscall.c
@@ -152,6 +152,9 @@ static muslcsys_syscall_t syscall_table[MUSLC_NUM_SYSCALLS] = {
 #ifdef __NR_mmap
     [__NR_mmap] = sys_mmap,
 #endif
+#ifdef __NR_munmap
+    [__NR_munmap] = sys_munmap,
+#endif
     [__NR_mremap] = sys_mremap,
     [__NR_madvise] = sys_madvise,
 };


### PR DESCRIPTION
This commit adds a dummy __NR_munmap call, which prevents the "libsel4muslcsys: Error attempting syscall 215" error from printing.

That print shows up during the ARM VMM boot process.