### PR TITLE
libsel4bench: add support for ARM Cortex-A55

### DIFF
--- a/libsel4bench/arch_include/arm/cpu/cortex-a55/sel4bench/cpu/events.h
+++ b/libsel4bench/arch_include/arm/cpu/cortex-a55/sel4bench/cpu/events.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, HENSOLDT Cyber GmbH
+ * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ *
+ * ARM Cortex-A55 performance monitoring events
+ *
+ */
+
+#pragma once
+
+// Events are defined in the Cortex-A55 TRM. Most recent version as of today is
+// "ARM 100442_0200_01_en" (2022-Aug-31, "Second release for r2p0"),
+// section 4.2.4 "PMU events". The definitions for the Cortex-A55 core are
+// aligned with the ARM Architecture Reference Manual for ARMv8. Most recent
+// version as of today is "ARM DDI 0487I.a" (2022-Aug-19, "Updated Armv9 EAC
+// release incorporating BRBE, ETE, and TRBE"). See section D11.11.2 "The PMU
+// event number space and common events"
+
+#define SEL4BENCH_EVENT_BUS_ACCESS_LD         0x60 /* BUS_ACCESS_RD */
+#define SEL4BENCH_EVENT_BUS_ACCESS_ST         0x61 /* BUS_ACCESS_WR */
+#define SEL4BENCH_EVENT_BR_INDIRECT_SPEC      0x7A
+#define SEL4BENCH_EVENT_EXC_IRQ               0x86
+#define SEL4BENCH_EVENT_EXC_FIQ               0x87


### PR DESCRIPTION
Another fix for https://github.com/seL4/sel4bench/issues/32

This fixed the error
```
  [182/299] Building C object apps/sel4bench/seL4_libs/libsel4bench/CMakeFiles/sel4bench.dir/src/arch/arm/armv/armv8-a/event_counters.c.obj
  FAILED: apps/sel4bench/seL4_libs/libsel4bench/CMakeFiles/sel4bench.dir/src/arch/arm/armv/armv8-a/event_counters.c.obj
  /usr/bin/ccache /usr/bin/aarch64-linux-gnu-gcc --sysroot=/github/workspace/build  -I/github/workspace/projects/seL4_libs/libsel4bench/include -I/github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/armv/armv8-a -I/github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/cpu/cortex-a55 -I/github/workspace/projects/seL4_libs/libsel4bench/sel4_arch_include/aarch64 -I/github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm -I/github/workspace/projects/seL4_libs/libsel4bench/src -Iapps/sel4bench/musllibc/build-temp/stage/include -I/github/workspace/kernel/libsel4/include -I/github/workspace/kernel/libsel4/arch_include/arm -I/github/workspace/kernel/libsel4/sel4_arch_include/aarch64 -I/github/workspace/kernel/libsel4/sel4_plat_include/quartz64 -I/github/workspace/kernel/libsel4/mode_include/64 -Ilibsel4/include -Ilibsel4/arch_include/arm -Ilibsel4/sel4_arch_include/aarch64 -I/github/workspace/projects/util_libs/libutils/include -I/github/workspace/projects/util_libs/libutils/arch_include/arm -Iapps/sel4bench/util_libs/libutils/gen_config -Ilibsel4/autoconf -Ikernel/gen_config -Ilibsel4/gen_config -march=armv8-a  -D__KERNEL_64__ -O3 -DNDEBUG -ffunction-sections -fdata-sections -nostdinc -fno-pic -fno-pie -fno-stack-protector -fno-asynchronous-unwind-tables -ftls-model=local-exec -mstrict-align -mno-outline-atomics -std=gnu11 -MD -MT apps/sel4bench/seL4_libs/libsel4bench/CMakeFiles/sel4bench.dir/src/arch/arm/armv/armv8-a/event_counters.c.obj -MF apps/sel4bench/seL4_libs/libsel4bench/CMakeFiles/sel4bench.dir/src/arch/arm/armv/armv8-a/event_counters.c.obj.d -o apps/sel4bench/seL4_libs/libsel4bench/CMakeFiles/sel4bench.dir/src/arch/arm/armv/armv8-a/event_counters.c.obj -c /github/workspace/projects/seL4_libs/libsel4bench/src/arch/arm/armv/armv8-a/event_counters.c
  In file included from /github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/armv/armv8-a/sel4bench/armv/private.h:9,
                   from /github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/armv/armv8-a/sel4bench/armv/sel4bench.h:10,
                   from /github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/sel4bench/arch/sel4bench.h:12,
                   from /github/workspace/projects/seL4_libs/libsel4bench/include/sel4bench/sel4bench.h:13,
                   from /github/workspace/projects/seL4_libs/libsel4bench/src/arch/arm/armv/armv8-a/../../event_counters.h:8,
                   from /github/workspace/projects/seL4_libs/libsel4bench/src/arch/arm/armv/armv8-a/event_counters.c:9:
  /github/workspace/projects/seL4_libs/libsel4bench/arch_include/arm/armv/armv8-a/sel4bench/armv/events.h:74:10: fatal error: sel4bench/cpu/events.h: No such file or directory
     74 | #include <sel4bench/cpu/events.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
```