### PR TITLE
libsel4test: Add smc cap to test env

### DIFF
--- a/libsel4simple-default/src/libsel4simple-default.c
+++ b/libsel4simple-default/src/libsel4simple-default.c
@@ -114,6 +114,12 @@ seL4_CPtr simple_default_nth_cap(void *data, int n)
             true_return++;
         }
 #endif
+#ifndef CONFIG_ALLOW_SMC_CALLS
+        /* skip seL4_CapSMC if SMC Calls are not enabled */
+        if (true_return >= seL4_CapSMC) {
+            true_return++;
+        }
+#endif
     } else if (n < shared_frame_range) {
         return bi->sharedFrames.start + (n - SIMPLE_NUM_INIT_CAPS);
     } else if (n < user_img_frame_range) {

--- a/libsel4simple/arch_include/arm/simple/arch/simple.h
+++ b/libsel4simple/arch_include/arm/simple/arch/simple.h
@@ -28,7 +28,13 @@
 #define SIMPLE_SKIP_SMMU_CAPS 2
 #endif
 
-#define SIMPLE_SKIPPED_INIT_CAPS (3 + SIMPLE_SKIP_THREADSC + SIMPLE_SKIP_SMMU_CAPS)
+#ifdef CONFIG_ALLOW_SMC_CALLS
+#define SIMPLE_SKIP_SMC 0
+#else
+#define SIMPLE_SKIP_SMC 1
+#endif
+
+#define SIMPLE_SKIPPED_INIT_CAPS (3 + SIMPLE_SKIP_THREADSC + SIMPLE_SKIP_SMMU_CAPS + SIMPLE_SKIP_SMC)
 
 /* Request a cap to a specific IRQ number on the system
  *

--- a/libsel4simple/arch_include/x86/simple/arch/simple.h
+++ b/libsel4simple/arch_include/x86/simple/arch/simple.h
@@ -15,7 +15,7 @@
 #include <vka/cspacepath_t.h>
 
 /* Simple does not address initial null caps, including seL4_CapNull
- * seL4_CapSMMUSIDControl, seL4_CapSMMUCBControl are null on x86 */
+ * seL4_CapSMMUSIDControl, seL4_CapSMMUCBControl, seL4_CapSMC are null on x86 */
 #ifdef CONFIG_IOMMU
 #define SIMPLE_SKIP_IOSPACE 0
 #else
@@ -29,7 +29,7 @@
 #define SIMPLE_SKIP_THREADSC 1
 #endif
 
-#define SIMPLE_SKIPPED_INIT_CAPS (3 + SIMPLE_SKIP_IOSPACE + SIMPLE_SKIP_THREADSC)
+#define SIMPLE_SKIPPED_INIT_CAPS (4 + SIMPLE_SKIP_IOSPACE + SIMPLE_SKIP_THREADSC)
 
 /**
  * Request a cap to the IOPorts

--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -56,6 +56,9 @@ struct env {
     seL4_CPtr asid_pool;
     seL4_CPtr asid_ctrl;
     seL4_CPtr sched_ctrl;
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    seL4_CPtr smc;
+#endif /* CONFIG_ALLOW_SMC_CALLS */
 #ifdef CONFIG_IOMMU
     seL4_CPtr io_space;
 #endif /* CONFIG_IOMMU */


### PR DESCRIPTION
This allows tests to have the initial smc cap when that support is enabled.

This is required for the new SMC test here: https://github.com/seL4/sel4test/pull/85