### PR TITLE
simple: Define SIMPLE_SKIPPED_INIT_CAPS better

### DIFF
--- a/libsel4simple-default/src/libsel4simple-default.c
+++ b/libsel4simple-default/src/libsel4simple-default.c
@@ -101,6 +101,19 @@ seL4_CPtr simple_default_nth_cap(void *data, int n)
             true_return++;
         }
 #endif
+#ifndef CONFIG_ARM_SMMU
+        /* skip seL4_CapSMMUSIDControl and seL4_CapSMMUCBControl if
+         * SMMU is not supported on this platform */
+        if (true_return >= seL4_CapSMMUSIDControl) {
+            true_return += 2;
+        }
+#endif
+#ifndef CONFIG_KERNEL_MCS
+        /* skip seL4_CapInitThreadSC if MCS is not enabled */
+        if (true_return >= seL4_CapInitThreadSC) {
+            true_return++;
+        }
+#endif
     } else if (n < shared_frame_range) {
         return bi->sharedFrames.start + (n - SIMPLE_NUM_INIT_CAPS);
     } else if (n < user_img_frame_range) {

--- a/libsel4simple/arch_include/arm/simple/arch/simple.h
+++ b/libsel4simple/arch_include/arm/simple/arch/simple.h
@@ -16,7 +16,19 @@
 
 /* Simple does not address initial null caps, including seL4_CapNull.
  * seL4_CapIOSpace, seL4_CapIOPortControl are null on architectures other than x86 */
-#define SIMPLE_SKIPPED_INIT_CAPS 3
+#ifdef CONFIG_KERNEL_MCS
+#define SIMPLE_SKIP_THREADSC 0
+#else
+#define SIMPLE_SKIP_THREADSC 1
+#endif
+
+#ifdef CONFIG_ARM_SMMU
+#define SIMPLE_SKIP_SMMU_CAPS 0
+#else
+#define SIMPLE_SKIP_SMMU_CAPS 2
+#endif
+
+#define SIMPLE_SKIPPED_INIT_CAPS (3 + SIMPLE_SKIP_THREADSC + SIMPLE_SKIP_SMMU_CAPS)
 
 /* Request a cap to a specific IRQ number on the system
  *

--- a/libsel4simple/arch_include/x86/simple/arch/simple.h
+++ b/libsel4simple/arch_include/x86/simple/arch/simple.h
@@ -41,7 +41,8 @@
  * @param dest The index within the CNode to put the cap
  * @param depth of index
  */
-typedef seL4_Error (*arch_simple_get_IOPort_cap_fn)(void *data, uint16_t start_port, uint16_t end_port, seL4_Word root, seL4_Word dest, seL4_Word depth);
+typedef seL4_Error(*arch_simple_get_IOPort_cap_fn)(void *data, uint16_t start_port, uint16_t end_port, seL4_Word root,
+                                                   seL4_Word dest, seL4_Word depth);
 
 /**
  * Request a cap to a specific MSI IRQ number on the system
@@ -52,12 +53,12 @@ typedef seL4_Error (*arch_simple_get_IOPort_cap_fn)(void *data, uint16_t start_p
  * @param the index within the CNode to put cap
  * @param Depth of index
  */
-typedef seL4_Error (*arch_simple_get_msi_fn)(void *data, seL4_CNode root, seL4_Word index,
-                                             uint8_t depth, seL4_Word pci_bus, seL4_Word pci_dev,
-                                             seL4_Word pci_func, seL4_Word handle,
-                                             seL4_Word vector);
+typedef seL4_Error(*arch_simple_get_msi_fn)(void *data, seL4_CNode root, seL4_Word index,
+                                            uint8_t depth, seL4_Word pci_bus, seL4_Word pci_dev,
+                                            seL4_Word pci_func, seL4_Word handle,
+                                            seL4_Word vector);
 
-typedef seL4_Error (*arch_simple_get_ioapic_fn)(void *data, seL4_CNode root, seL4_Word index,
+typedef seL4_Error(*arch_simple_get_ioapic_fn)(void *data, seL4_CNode root, seL4_Word index,
                                                uint8_t depth, seL4_Word ioapic, seL4_Word pin,
                                                seL4_Word level, seL4_Word polarity,
                                                seL4_Word vector);
@@ -71,8 +72,8 @@ typedef seL4_Error (*arch_simple_get_ioapic_fn)(void *data, seL4_CNode root, seL
  * @param the index within the CNode to put cap
  * @param Depth of index
  */
-typedef seL4_Error (*arch_simple_get_IRQ_handler_fn)(void *data, int irq, seL4_CNode cnode, seL4_Word index,
-                                                     uint8_t depth);
+typedef seL4_Error(*arch_simple_get_IRQ_handler_fn)(void *data, int irq, seL4_CNode cnode, seL4_Word index,
+                                                    uint8_t depth);
 
 #ifdef CONFIG_IOMMU
 /**
@@ -84,8 +85,8 @@ typedef seL4_Error (*arch_simple_get_IRQ_handler_fn)(void *data, int irq, seL4_C
  * @param path Path to where to put this cap
  *
 */
-typedef seL4_Error (*arch_simple_get_iospace_fn)(void *data, uint16_t domainID, uint16_t deviceID,
-                                                 cspacepath_t *path);
+typedef seL4_Error(*arch_simple_get_iospace_fn)(void *data, uint16_t domainID, uint16_t deviceID,
+                                                cspacepath_t *path);
 
 #endif
 
@@ -100,8 +101,8 @@ typedef struct arch_simple {
     arch_simple_get_ioapic_fn ioapic;
 } arch_simple_t;
 
-static inline seL4_Error
-arch_simple_get_IOPort_cap(arch_simple_t *arch_simple, uint16_t start_port, uint16_t end_port, seL4_Word root, seL4_Word dest, seL4_Word depth)
+static inline seL4_Error arch_simple_get_IOPort_cap(arch_simple_t *arch_simple, uint16_t start_port, uint16_t end_port,
+                                                    seL4_Word root, seL4_Word dest, seL4_Word depth)
 {
     if (!arch_simple) {
         ZF_LOGE("Arch-simple is NULL");
@@ -116,10 +117,9 @@ arch_simple_get_IOPort_cap(arch_simple_t *arch_simple, uint16_t start_port, uint
     return arch_simple->IOPort_cap(arch_simple->data, start_port, end_port, root, dest, depth);
 }
 
-static inline seL4_Error
-arch_simple_get_msi(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word pci_bus,
-                    seL4_Word pci_dev, seL4_Word pci_func, seL4_Word handle,
-                    seL4_Word vector)
+static inline seL4_Error arch_simple_get_msi(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word pci_bus,
+                                             seL4_Word pci_dev, seL4_Word pci_func, seL4_Word handle,
+                                             seL4_Word vector)
 {
     if (!arch_simple) {
         ZF_LOGE("Arch-simple is NULL");
@@ -134,10 +134,9 @@ arch_simple_get_msi(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word pci
                             pci_dev, pci_func, handle, vector);
 }
 
-static inline seL4_Error
-arch_simple_get_ioapic(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word ioapic,
-                       seL4_Word pin, seL4_Word level, seL4_Word polarity,
-                       seL4_Word vector)
+static inline seL4_Error arch_simple_get_ioapic(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word ioapic,
+                                                seL4_Word pin, seL4_Word level, seL4_Word polarity,
+                                                seL4_Word vector)
 {
     if (!arch_simple) {
         ZF_LOGE("Arch-simple is NULL");
@@ -153,8 +152,8 @@ arch_simple_get_ioapic(arch_simple_t *arch_simple, cspacepath_t path, seL4_Word 
 }
 
 #ifdef CONFIG_IOMMU
-static inline seL4_CPtr
-arch_simple_get_iospace(arch_simple_t *arch_simple, uint16_t domainID, uint16_t deviceID, cspacepath_t *path)
+static inline seL4_CPtr arch_simple_get_iospace(arch_simple_t *arch_simple, uint16_t domainID, uint16_t deviceID,
+                                                cspacepath_t *path)
 {
     if (!arch_simple) {
         ZF_LOGE("Arch-simple is NULL");

--- a/libsel4simple/arch_include/x86/simple/arch/simple.h
+++ b/libsel4simple/arch_include/x86/simple/arch/simple.h
@@ -14,13 +14,22 @@
 #include <utils/util.h>
 #include <vka/cspacepath_t.h>
 
-/* Simple does not address initial null caps, including seL4_CapNull */
+/* Simple does not address initial null caps, including seL4_CapNull
+ * seL4_CapSMMUSIDControl, seL4_CapSMMUCBControl are null on x86 */
 #ifdef CONFIG_IOMMU
-#define SIMPLE_SKIPPED_INIT_CAPS 1
+#define SIMPLE_SKIP_IOSPACE 0
 #else
 /* seL4_CapIOSpace is null if IOMMU isn't supported */
-#define SIMPLE_SKIPPED_INIT_CAPS 2
+#define SIMPLE_SKIP_IOSPACE 1
 #endif
+
+#ifdef CONFIG_KERNEL_MCS
+#define SIMPLE_SKIP_THREADSC 0
+#else
+#define SIMPLE_SKIP_THREADSC 1
+#endif
+
+#define SIMPLE_SKIPPED_INIT_CAPS (3 + SIMPLE_SKIP_IOSPACE + SIMPLE_SKIP_THREADSC)
 
 /**
  * Request a cap to the IOPorts


### PR DESCRIPTION
Make sure this macro is defined based on all possible configurations.

Required based on this change: https://github.com/seL4/seL4/pull/1088