### PR TITLE
libsel4test,aarch64,smc: Add smc initial cap field

### DIFF
--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -62,6 +62,9 @@ struct env {
 #ifdef CONFIG_TK1_SMMU
     seL4_SlotRegion io_space_caps;
 #endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    seL4_CPtr smc_cap;
+#endif
     seL4_Word cores;
     seL4_CPtr domain;
     seL4_CPtr device_frame;


### PR DESCRIPTION
Add an initial smc cap to the test environment struct so that tests can use it.