### PR TITLE
allocman: fix build warning on native X86 simulate

### DIFF
--- a/libsel4allocman/src/allocman.c
+++ b/libsel4allocman/src/allocman.c
@@ -522,7 +522,7 @@ int allocman_configure_utspace_reserve(allocman_t *alloc, struct allocman_utspac
      * icnreasing reservations, but I cannot see the use case for that */
     for (i = 0; i < alloc->num_utspace_chunks; i++) {
         if (alloc->utspace_chunk[i].size_bits == chunk.size_bits && alloc->utspace_chunk[i].type == chunk.type) {
-            ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
+            ZF_LOGE("Failed to set reserve for {type: %"SEL4_PRIu_word" size_bits: %zu} as one already exists.", chunk.type, chunk.size_bits);
             ZF_LOGE("Ignoring this could cause the allocator to break in hard-to-identify ways.");
             error = 1;
             goto exit;
@@ -584,7 +584,7 @@ int allocman_configure_mspace_reserve(allocman_t *alloc, struct allocman_mspace_
      * icnreasing reservations, but I cannot see the use case for that */
     for (i = 0; i < alloc->num_mspace_chunks; i++) {
         if (alloc->mspace_chunk[i].size == chunk.size) {
-            ZF_LOGE("Failed to set reserve for {size: %d} as one already exists.", chunk.size);
+            ZF_LOGE("Failed to set reserve for {size: %zu} as one already exists.", chunk.size);
             ZF_LOGE("Ignoring this could cause the allocator to break in hard-to-identify ways.");
             error = 1;
             goto exit;


### PR DESCRIPTION
allocman: fix build warning on native X86 simulate

```
archer@c:~/code/sel4/build-x86$ ninja
[1/6] Building C object apps/sel4test-driver/seL4_libs/libsel4allocman/CMakeFiles/sel4allocman.dir/src/allocman.c.obj
In file included from /home/archer/code/sel4/projects/util_libs/libutils/include/utils/util.h:46,
                 from /home/archer/code/sel4/projects/seL4_libs/libsel4utils/include/sel4utils/util.h:13,
                 from /home/archer/code/sel4/projects/seL4_libs/libsel4allocman/include/allocman/util.h:20,
                 from /home/archer/code/sel4/projects/seL4_libs/libsel4allocman/include/allocman/allocman.h:51,
                 from /home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:7:
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c: In function ‘allocman_configure_utspace_reserve’:
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:21: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘seL4_Word’ {aka ‘long unsigned int’} [-Wformat=]
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                                                                       |
      |                                                                                                       seL4_Word {aka long unsigned int}
/home/archer/code/sel4/projects/util_libs/libutils/include/utils/zf_log.h:302:67: note: in definition of macro ‘_ZF_LOG_IMP’
  302 |                                                         lvl, tag, __VA_ARGS__); \
      |                                                                   ^~~~~~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:13: note: in expansion of macro ‘ZF_LOGE’
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |             ^~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:56: note: format string is defined here
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |                                                       ~^
      |                                                        |
      |                                                        int
      |                                                       %ld
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:21: warning: format ‘%d’ expects argument of type ‘int’, but argument 8 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~              ~~~~~~~~~~~~~~~
      |                                                                                                                   |
      |                                                                                                                   size_t {aka long unsigned int}
/home/archer/code/sel4/projects/util_libs/libutils/include/utils/zf_log.h:302:67: note: in definition of macro ‘_ZF_LOG_IMP’
  302 |                                                         lvl, tag, __VA_ARGS__); \
      |                                                                   ^~~~~~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:13: note: in expansion of macro ‘ZF_LOGE’
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |             ^~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:525:70: note: format string is defined here
  525 |             ZF_LOGE("Failed to set reserve for {type: %d size_bits: %d} as one already exists.", chunk.type, chunk.size_bits);
      |                                                                     ~^
      |                                                                      |
      |                                                                      int
      |                                                                     %ld
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c: In function ‘allocman_configure_mspace_reserve’:
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:587:21: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  587 |             ZF_LOGE("Failed to set reserve for {size: %d} as one already exists.", chunk.size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                                                         |
      |                                                                                         size_t {aka long unsigned int}
/home/archer/code/sel4/projects/util_libs/libutils/include/utils/zf_log.h:302:67: note: in definition of macro ‘_ZF_LOG_IMP’
  302 |                                                         lvl, tag, __VA_ARGS__); \
      |                                                                   ^~~~~~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:587:13: note: in expansion of macro ‘ZF_LOGE’
  587 |             ZF_LOGE("Failed to set reserve for {size: %d} as one already exists.", chunk.size);
      |             ^~~~~~~
/home/archer/code/sel4/projects/seL4_libs/libsel4allocman/src/allocman.c:587:56: note: format string is defined here
  587 |             ZF_LOGE("Failed to set reserve for {size: %d} as one already exists.", chunk.size);
      |                                                       ~^
      |                                                        |
      |                                                        int
      |                                                       %ld
[6/6] Generating ../../images/sel4test-driver-image-x86_64-pc99

```