### PR TITLE
CI: use proper step name

### DIFF
--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  cparser:
+  simulation:
     name: Simulation
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Fix copy/paste bug with the name. Has been there thing the beginnin, see 99b96310