### PR TITLE
sel4muslcsys: Fix up llseek on 32bit arch

### DIFF
--- a/libsel4muslcsys/CMakeLists.txt
+++ b/libsel4muslcsys/CMakeLists.txt
@@ -73,7 +73,7 @@ list(SORT deps)
 # TODO: This use to be calculated by the following line. Need to use a generator expression and generate
 # this into a header file at build time
 # MUSLC_HIGHEST_SYSCALL := $(shell cat $(STAGE_DIR)/include/bits/syscall.h | sed 's/^.*[^0-9]\([0-9]*\)$$/\1/' | sort -nr | head -1)
-set(HighestSyscall 400)
+set(HighestSyscall 452)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=700 -DMUSLC_HIGHEST_SYSCALL=${HighestSyscall}")
 

--- a/libsel4muslcsys/src/vsyscall.c
+++ b/libsel4muslcsys/src/vsyscall.c
@@ -138,7 +138,9 @@ static muslcsys_syscall_t syscall_table[MUSLC_NUM_SYSCALLS] = {
     [__NR_read] = sys_read,
     [__NR_ioctl] = sys_ioctl,
     [__NR_prlimit64] = sys_prlimit64,
+#ifdef __NR_lseek
     [__NR_lseek] = sys_lseek,
+#endif
 #ifdef __NR__llseek
     [__NR__llseek] = sys__llseek,
 #endif


### PR DESCRIPTION
riscv32 linux abi doesn't define lseek. Instead llseek uses 2 32bit arguments for a 64bit offset and returns the value via a pointer to 64bit value in user memory.

Instead of calling a syscall within a syscall, just make a shared internal function to call for both lseek and llseek.