### PR TITLE
sel4bench: Do not disable counters for armv7-a.

### DIFF
--- a/libsel4bench/arch_include/arm/armv/armv7-a/sel4bench/armv/sel4bench.h
+++ b/libsel4bench/arch_include/arm/armv/armv7-a/sel4bench/armv/sel4bench.h
@@ -85,12 +85,7 @@ static FASTFN seL4_Word sel4bench_get_num_counters()
 static FASTFN ccnt_t sel4bench_get_cycle_count()
 {
     ccnt_t val;
-    uint32_t enable_word = sel4bench_private_read_cntens(); //store running state
-
-    sel4bench_private_write_cntenc(BIT(SEL4BENCH_ARMV7A_COUNTER_CCNT)); //stop CCNT
     SEL4BENCH_READ_CCNT(val); //read its value
-    sel4bench_private_write_cntens(enable_word); //start it again if it was running
-
     return val;
 }
 


### PR DESCRIPTION
The same scenario as for aarch64: If the cycle counter is disabled during a read, the operation can be preempted and lose the count of cycles for the duration of the preemption.
Closes Issue: #34 