### PR TITLE
Bump minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_subdirectory(libsel4debug)
 add_subdirectory(libsel4allocman)

--- a/libsel4allocman/CMakeLists.txt
+++ b/libsel4allocman/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4allocman C)
 

--- a/libsel4bench/CMakeLists.txt
+++ b/libsel4bench/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4bench C)
 

--- a/libsel4debug/CMakeLists.txt
+++ b/libsel4debug/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4debug C ASM)
 

--- a/libsel4muslcsys/CMakeLists.txt
+++ b/libsel4muslcsys/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4muslcsys C)
 

--- a/libsel4platsupport/CMakeLists.txt
+++ b/libsel4platsupport/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4platsupport C ASM)
 

--- a/libsel4serialserver/CMakeLists.txt
+++ b/libsel4serialserver/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4serialserver C)
 

--- a/libsel4simple-default/CMakeLists.txt
+++ b/libsel4simple-default/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4simple-default C)
 

--- a/libsel4simple/CMakeLists.txt
+++ b/libsel4simple/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4simple C)
 

--- a/libsel4sync/CMakeLists.txt
+++ b/libsel4sync/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4ync C)
 

--- a/libsel4test/CMakeLists.txt
+++ b/libsel4test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4test C)
 

--- a/libsel4utils/CMakeLists.txt
+++ b/libsel4utils/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4utils C)
 

--- a/libsel4vka/CMakeLists.txt
+++ b/libsel4vka/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4vka C)
 

--- a/libsel4vspace/CMakeLists.txt
+++ b/libsel4vspace/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4vspace C)
 


### PR DESCRIPTION
Compatibility with versions <3.10 is going away.
As it happens, we're not using any CMake features that have changed between 3.7 and 3.16, so bump the lowest version to 3.16.