### PR TITLE
github: use central CI workflows

### DIFF
--- a/.github/workflows/hw-tests.yml
+++ b/.github/workflows/hw-tests.yml
@@ -1,0 +1,26 @@
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# sel4test and sel4bench hardware builds and runs
+#
+# See sel4test-hw/builds.yml and sel4bench-hw/builds.yml in the repo
+# seL4/ci-actions for configs.
+
+name: HW
+
+on:
+  # needs PR target for secrets access; guard by requiring label
+  pull_request_target:
+    types: [synchronize, labeled]
+
+jobs:
+  sel4test:
+    name: seL4Test
+    uses: seL4/ci-actions/.github/workflows/sel4test-hw.yml@master
+    secrets: inherit
+
+  sel4bench:
+    name: seL4Bench
+    uses: seL4/ci-actions/.github/workflows/sel4bench-hw.yml@master
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2025, Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -6,23 +6,9 @@
 
 name: PR
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
-  gitlint:
-    name: Gitlint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/gitlint@master
-
-  whitespace:
-    name: 'Trailing Whitespace'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/git-diff-check@master
-
-  shell:
-    name: 'Portable Shell'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/bashisms@master
+  pr-checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/pr.yml@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,26 +10,9 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  check:
-    name: License Check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/license-check@master
-
-  links:
-    name: Links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seL4/ci-actions/link-check@master
-        with:
-          exclude: js/node_modules
-
-  style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/style@master
-      with:
-        diff_only: true
+  checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/push.yml@master

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -9,28 +9,13 @@
 name: seL4Test
 
 on:
-  push:
-    branches: [master]
   pull_request:
-
-
-# Cancel older runs of this workflow that are still not finished for the
-# current PR. This reduces the CI load. For deployment to the master branch,
-# the workflow will run on each push, but no cancellation happens here.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    paths-ignore:
+      - 'LICENSES/**'
+      - '*.md'
+  workflow_dispatch:
 
 jobs:
-  simulation:
-    name: Simulation
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        march: [armv7a, armv8a, nehalem, rv32imac, rv64imac]
-        compiler: [gcc, clang]
-    steps:
-    - uses: seL4/ci-actions/sel4test-sim@master
-      with:
-        march: ${{ matrix.march }}
-        compiler: ${{ matrix.compiler }}
+  sim:
+    name: Sim
+    uses: seL4/ci-actions/.github/workflows/sel4test-sim.yml@master


### PR DESCRIPTION
Use GitHub workflow_call feature to reduce workflow duplication.

Includes sel4test and sel4bench hw tests now.