### PR TITLE
libsel4muslcsys: Add fstat syscall

### DIFF
--- a/libsel4muslcsys/src/sys_io.c
+++ b/libsel4muslcsys/src/sys_io.c
@@ -21,6 +21,7 @@
 #include <sys/resource.h>
 #include <sys/mman.h>
 #include <sys/uio.h>
+#include <sys/stat.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -258,6 +259,28 @@ long sys_close(va_list ap)
     return 0;
 }
 
+long sys_fstat(va_list ap)
+{
+    int fd = va_arg(ap, int);
+    struct stat *statbuf = va_arg(ap, struct stat *);
+
+    if (fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        memset(statbuf, 0, sizeof(struct stat));
+
+        if (fd == STDIN_FILENO) {
+            statbuf->st_mode = S_IRUSR;
+        } else {
+            statbuf->st_mode = S_IWUSR;
+        }
+
+        return 0;
+    } else if (valid_fd(fd)) {
+        assert(!"not implemented");
+        return -EBADF;
+    } else {
+        return -EBADF;
+    }
+}
 
 static write_buf_fn stdio_write = sys_platform_write;
 

--- a/libsel4muslcsys/src/syscalls.h
+++ b/libsel4muslcsys/src/syscalls.h
@@ -37,3 +37,4 @@ long sys_mremap(va_list ap);
 long sys_write(va_list ap);
 long sys_writev(va_list ap);
 long sys_madvise(va_list ap);
+long sys_fstat(va_list ap);

--- a/libsel4muslcsys/src/vsyscall.c
+++ b/libsel4muslcsys/src/vsyscall.c
@@ -134,6 +134,7 @@ static muslcsys_syscall_t syscall_table[MUSLC_NUM_SYSCALLS] = {
     [__NR_openat] = sys_openat,
 #endif
     [__NR_close] = sys_close,
+    [__NR_fstat] = sys_fstat,
     [__NR_readv] = sys_readv,
     [__NR_read] = sys_read,
     [__NR_ioctl] = sys_ioctl,


### PR DESCRIPTION
The implementation only sets the file mode.
It is also only implemented for STDIN, STDOUT and STDERR.

This is to support libraries that insist on calling fstat on file descriptors before doing I/O.