### PR TITLE
sel4test: Handle retain attr issue in build args

### DIFF
--- a/libsel4test/CMakeLists.txt
+++ b/libsel4test/CMakeLists.txt
@@ -38,6 +38,12 @@ file(GLOB deps src/*.c)
 list(SORT deps)
 
 add_library(sel4test STATIC EXCLUDE_FROM_ALL ${deps})
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_definitions(sel4test PUBLIC "LIBSEL4TEST_ATTR_RETAIN=__attribute__((used,retain))")
+else()
+    target_compile_definitions(sel4test PUBLIC "LIBSEL4TEST_ATTR_RETAIN=__attribute__((used))")
+endif()
+
 target_include_directories(sel4test PUBLIC include)
 target_link_libraries(
     sel4test

--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -96,16 +96,10 @@ typedef struct test_type {
     test_result_t (*run_test)(struct testcase *test, uintptr_t e);
 } ALIGN(32) test_type_t;
 
-#if defined(__has_attribute) && __has_attribute(retain)
-#define ATTR_USED_RETAIN __attribute__((used,retain))
-#else
-#define ATTR_USED_RETAIN __attribute__((used))
-#endif
-
 /* Declare a test type.
  * For now, we put the test types in a separate elf section. */
 #define DEFINE_TEST_TYPE(_name, _id, _set_up_test_type, _tear_down_test_type, _set_up, _tear_down, _run_test) \
-    ATTR_USED_RETAIN __attribute__((section("_test_type"))) \
+    LIBSEL4TEST_ATTR_RETAIN __attribute__((section("_test_type"))) \
     struct test_type TEST_TYPE_ ##_name = { \
     .name = #_name, \
     .id = _id, \
@@ -141,7 +135,7 @@ typedef struct testcase ALIGN(sizeof(struct testcase)) testcase_t;
  * that it is accepted by C++ compilers.
  */
 #define DEFINE_TEST_WITH_TYPE(_name, _description, _function, _test_type, _enabled) \
-    ATTR_USED_RETAIN __attribute__((section("_test_case"))) \
+    LIBSEL4TEST_ATTR_RETAIN __attribute__((section("_test_case"))) \
     struct testcase TEST_ ## _name = { \
     #_name, \
     _description, \


### PR DESCRIPTION
It seems that detecting support for the right keywords used to instruct the linker to retain symbols is pretty unstable. Alternative approach is to move conditional check into the build script and pick behavior based on the toolchains selected.

An approach to address https://github.com/seL4/seL4_libs/issues/97
