### PR TITLE
Limit retain to Clang

### DIFF
--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -96,7 +96,7 @@ typedef struct test_type {
     test_result_t (*run_test)(struct testcase *test, uintptr_t e);
 } ALIGN(32) test_type_t;
 
-#if defined(__has_attribute) && __has_attribute(retain)
+#if defined(__has_attribute) && __has_attribute(retain) && defined(__clang__)
 #define ATTR_USED_RETAIN __attribute__((used,retain))
 #else
 #define ATTR_USED_RETAIN __attribute__((used))


### PR DESCRIPTION
Because of GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587 using has_attribute is not reliable and can give compile warnings that will be turned into errors because of -Werror.

The retain atribute was added to support linking with LLVM's linker by commit 12d0d9, as clang has LTO enabled by default, so limiting it to CLang is fine until GCC enables LTO too.

This fixes issue #97.