### PR TITLE
libsel4test: static_assert sizeof() mismatches & check against unsigned char support

### DIFF
--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -256,10 +256,12 @@ static inline void print_error_in_ipc(seL4_Error e)
              test_op_type(_a, _b, op, "%llu", a, b, unsigned long long); \
          } else if (TYPES_COMPATIBLE(typeof(_a), char)) {\
              test_op_type(_a, _b, op, "%c", a, b, char); \
+         } else if (TYPES_COMPATIBLE(typeof(_a), unsigned char)) {\
+             test_op_type(_a, _b, op, "%c", a, b, unsigned char); \
          } else if (TYPES_COMPATIBLE(typeof(_a), uintptr_t)) {\
              test_op_type(_a, _b, op, "0x%" PRIxPTR, a, b, uintptr_t);\
          } else { \
-             _test_error("Cannot use test_op on this type", __FILE__, __LINE__);\
+             _test_abort("Cannot use test_op on this type", __FILE__, __LINE__);\
          }\
     } while (0)
 

--- a/libsel4test/include/sel4test/test.h
+++ b/libsel4test/include/sel4test/test.h
@@ -240,14 +240,9 @@ static inline void print_error_in_ipc(seL4_Error e)
     do { \
          typeof (a) _a = (a); \
          typeof (b) _b = (b); \
-         if (sizeof(_a) != sizeof(_b)) { \
-             int len = snprintf(NULL, 0, "%s (size %zu) != %s (size %zu), use of test_eq incorrect", #a,\
-                     sizeof(_a), #b, sizeof(_b)) + 1;\
-             char buffer[len];\
-             snprintf(buffer, len, "%s (size %zu) != %s (size %zu), use of test_eq incorrect", #a, sizeof(_a),\
-                     #b, sizeof(_b));\
-             _test_error(buffer, __FILE__, __LINE__);\
-         } else if (TYPES_COMPATIBLE(typeof(_a), int)) {\
+         _Static_assert(sizeof(_a) == sizeof(_b), \
+                        "sizeof(" #a ") does not match sizeof(" #b "), use of test_eq incorrect"); \
+         if (TYPES_COMPATIBLE(typeof(_a), int)) {\
              test_op_type(_a, _b, op, "%d", a, b, int); \
          } else if (TYPES_COMPATIBLE(typeof(_a), long)) {\
              test_op_type(_a, _b, op, "%ld", a, b, long); \
@@ -302,4 +297,3 @@ static inline void print_error_in_ipc(seL4_Error e)
 #define test_strleq(a, b) test_strop(a, b, <=)
 
 env_t sel4test_get_env(void);
-


### PR DESCRIPTION
Commit 1:

This would previously fail at runtime, but we can fail the build
instead and catch this earlier.

	In file included from /src/helpers.h:13,
	                 from /src/tests/ipc.c:13:
	/projects/sel4test/apps/sel4test-tests/src/tests/ipc.c:
	  In function ‘test_ipc_pair’:
	/projects/seL4_libs/libsel4test/include/sel4test/test.h:243:10:
	  error: static assertion failed: "sizeof(res) does not match
	         sizeof(SUCCESS), use of test_eq incorrect"
	
	  243 |          _Static_assert(sizeof(_a) == sizeof(_b), \
	      |          ^~~~~~~~~~~~~~
	
	/projects/seL4_libs/libsel4test/include/sel4test/test.h:270:24:
	  note: in expansion of macro ‘test_op’
	
	  270 | #define test_eq(a, b)  test_op(a, b, ==)
	      |                        ^~~~~~~
	
	/projects/sel4test/apps/sel4test-tests/src/tests/ipc.c:347:25:
	  note: in expansion of macro ‘test_eq’
	
	  347 |                         test_eq(res, SUCCESS);
	      |                         ^~~~~~~

Commit 2:

On arm-none-elf-eabi-gcc, -fshort-enums is on by default and
is compatible with unsigned char (but not *signed* char) so we
need to add support for this to the test_op macros.

Also, _test_abort() when these type failures happen so that the
failure is more obviously an issue with the compiler/test setup,
not the tests themselves.

Test with: https://github.com/seL4/sel4test/pull/145