### PR TITLE
Use seL4_UserVSpaceTop for KERNEL_RESERVED_START

### DIFF
--- a/libsel4utils/include/sel4utils/vspace.h
+++ b/libsel4utils/include/sel4utils/vspace.h
@@ -35,7 +35,7 @@
 /* These definitions are only here so that you can take the size of them.
  * TOUCHING THESE DATA STRUCTURES IN ANY WAY WILL BREAK THE WORLD
  */
-#define KERNEL_RESERVED_START (ALIGN_DOWN(seL4_UserTop, PAGE_SIZE_4K))
+#define KERNEL_RESERVED_START (seL4_UserVSpaceTop + 1)
 #define VSPACE_LEVEL_SIZE BIT(VSPACE_LEVEL_BITS)
 
 typedef struct vspace_mid_level {

--- a/libsel4utils/include/sel4utils/vspace_internal.h
+++ b/libsel4utils/include/sel4utils/vspace_internal.h
@@ -24,8 +24,11 @@
 #define INDEX_FOR_LEVEL(addr, l) ( ( (addr) >> ((l) * VSPACE_LEVEL_BITS + PAGE_BITS_4K)) & MASK(VSPACE_LEVEL_BITS))
 #define TOP_LEVEL_INDEX(x) INDEX_FOR_LEVEL(x, VSPACE_NUM_LEVELS - 1)
 
-#define BYTES_FOR_LEVEL(l) BIT(VSPACE_LEVEL_BITS * (l) + PAGE_BITS_4K)
-#define ALIGN_FOR_LEVEL(l) (~(MASK(VSPACE_LEVEL_BITS * (l) + PAGE_BITS_4K)))
+#define BITS_FOR_LEVEL(l) (VSPACE_LEVEL_BITS * (l) + PAGE_BITS_4K)
+#define BYTES_FOR_LEVEL(l) BIT(BITS_FOR_LEVEL(l))
+#define ALIGN_FOR_LEVEL(l) (~(MASK(BITS_FOR_LEVEL(l))))
+
+#define VSPACE_VA_TOP (MASK(BITS_FOR_LEVEL(VSPACE_NUM_LEVELS)))
 
 void *create_level(vspace_t *vspace, size_t size);
 void *bootstrap_create_level(vspace_t *vspace, size_t size);

--- a/libsel4utils/src/vspace/bootstrap.c
+++ b/libsel4utils/src/vspace/bootstrap.c
@@ -52,12 +52,20 @@ static int common_init(vspace_t *vspace, vka_t *vka, seL4_CPtr vspace_root,
 static void common_init_post_bootstrap(vspace_t *vspace, sel4utils_map_page_fn map_page)
 {
     sel4utils_alloc_data_t *data = get_alloc_data(vspace);
-    /* reserve the kernel region, we do this by marking the
-     * top level entry as RESERVED */
-    if (!data->is_empty) {
-        for (int i = TOP_LEVEL_INDEX(KERNEL_RESERVED_START);
-             i < VSPACE_LEVEL_SIZE; i++) {
-            data->top_level->table[i] = RESERVED;
+
+    /* We only have regions to reserve if the seL4_UserVSpaceTop is less than
+     * the top of the VA range. This happens for for AArch64 hyp-mode with
+     * a PA Range of 2^40. Otherwise, we would be reserving random indices
+     * at the bottom of the virtual address range due to wrapping.
+     */
+    if (seL4_UserVSpaceTop <= VSPACE_VA_TOP) {
+        /* reserve the kernel region, we do this by marking the
+         * top level entry as RESERVED */
+        if (!data->is_empty) {
+            for (int i = TOP_LEVEL_INDEX(KERNEL_RESERVED_START);
+                 i < VSPACE_LEVEL_SIZE; i++) {
+                data->top_level->table[i] = RESERVED;
+            }
         }
     }
 


### PR DESCRIPTION
This value is consistent across platforms. Note that the previous definition incorrectly rounded down the inclusive addresses used by architectures e.g. AArch64.

Test with: https://github.com/seL4/seL4/pull/1695