### PR TITLE
libsel4bench: add support for ARM Cortex-A76

### DIFF
--- a/libsel4bench/arch_include/arm/cpu/cortex-a76/sel4bench/cpu/events.h
+++ b/libsel4bench/arch_include/arm/cpu/cortex-a76/sel4bench/cpu/events.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*
+ * Validated against Arm Cortex-A76 TRM, version 0401, table 18-1 "PMU events".
+ *
+ * https://developer.arm.com/documentation/100798/0401/Performance-Monitoring-Unit/PMU-events
+ */
+
+#pragma once
+/* BUS_ACCESS_RD in table 18-1 */
+#define SEL4BENCH_EVENT_BUS_ACCESS_LD         0x60
+/* BUS_ACCESS_WR in table 18-1 */
+#define SEL4BENCH_EVENT_BUS_ACCESS_ST         0x61
+
+#define SEL4BENCH_EVENT_BR_INDIRECT_SPEC      0x7A
+
+#define SEL4BENCH_EVENT_EXC_IRQ               0x86
+#define SEL4BENCH_EVENT_EXC_FIQ               0x87


### PR DESCRIPTION
Same values as for Cortex-A72 and before, validated against Arm Cortex-A76 TRM here:

https://developer.arm.com/documentation/100798/0401/Performance-Monitoring-Unit/PMU-events

(The other events.h files are copies, so I made a copy here as well instead of a symlink)

This fixes the sel4bench build failure.