### PR TITLE
sys_morecore: add underflow guard

### DIFF
--- a/libsel4muslcsys/src/sys_morecore.c
+++ b/libsel4muslcsys/src/sys_morecore.c
@@ -199,6 +199,10 @@ static long sys_mmap_impl_static(void *addr, size_t length, int prot, int flags,
         uintptr_t adjusted_length = pages * PAGE_SIZE_4K;
 
         /* Steal from the top */
+        /* Guard against unsigned underflow/wrap */
+        if (adjusted_length > morecore_top) {
+            return -ENOMEM;
+        }
         uintptr_t base = morecore_top - adjusted_length;
         if (base < morecore_base) {
             return -ENOMEM;


### PR DESCRIPTION
`morecore_top - adjusted_length` in the next line can underflow and wrap, rendering the `base < morecore_base` check below incorrect.

This came up when I was digging around for the kernel lock bug. This doesn't really change anything, but makes the path of chasing random numbers a bit shorter in the future.
