### PR TITLE
libsel4allocman: overflow guards for large UT

### DIFF
--- a/libsel4allocman/src/bootstrap.c
+++ b/libsel4allocman/src/bootstrap.c
@@ -1067,7 +1067,7 @@ static int handle_device_untyped_cap(add_untypeds_state_t *state, uintptr_t padd
 {
     bool cap_tainted = false;
     int error;
-    uintptr_t ut_end = paddr + BIT(size_bits);
+    uint64_t ut_end = (uint64_t)paddr + BIT(size_bits);
     int num_regions = 0;
     if (state != NULL) {
         num_regions = state->num_regions;

--- a/libsel4allocman/src/utspace/split.c
+++ b/libsel4allocman/src/utspace/split.c
@@ -137,7 +137,7 @@ static int _refill_pool(allocman_t *alloc, utspace_split_t *split, struct utspac
             if (node->paddr == ALLOCMAN_NO_PADDR) {
                 continue;
             }
-            if (node->paddr <= paddr && paddr < node->paddr + BIT(size_bits)) {
+            if (node->paddr <= paddr && paddr <= node->paddr + MASK(size_bits)) {
                 return 0;
             }
         }
@@ -159,7 +159,7 @@ static int _refill_pool(allocman_t *alloc, utspace_split_t *split, struct utspac
         node = heads[size_bits + 1];
     } else {
         for (node = heads[size_bits + 1]; node && (node->paddr == ALLOCMAN_NO_PADDR || !(node->paddr <= paddr
-                                                                                         && paddr < node->paddr + BIT(size_bits + 1))); node = node->next);
+                                                                                         && paddr <= node->paddr + MASK(size_bits + 1))); node = node->next);
         /* _refill_pool should not have returned if this wasn't possible */
         assert(node);
     }
@@ -227,7 +227,7 @@ static struct utspace_split_node **find_head_for_paddr(struct utspace_split_node
                 /* skip nodes with no physical address */
                 continue;
             }
-            if (node->paddr <= paddr && paddr + BIT(size_bits) <= node->paddr + BIT(i)) {
+            if (node->paddr <= paddr && paddr + MASK(size_bits) <= node->paddr + MASK(i)) {
                 return head;
             }
         }


### PR DESCRIPTION
seL4 can and does produce Untypeds that reach the end of the address space. Using `start + BIT(size)` is not overflow safe for these.

Replace this pattern with `MASK` instead for inclusive-end reasoning, or explicitly use `uint64_t` where that is too inconvenient.

The latter does rely on the fact that we will not get Untypeds that reach 2^64. It does look like no architecture so far has a full 64-bit physical address space, so this should be impossible.

This is not a full overflow safety survey of all of `libsel4allocman`, just what I found by searching for "BIT(". It at least does fix the errors I was getting for `zcu102` which does now produce such an untyped cap.

There are a bunch more occurrences in `twinkle.c`, but they look Ok, they seem to be computing offsets inside an UT, not going above the actual UT end.

(This should be no behaviour change to before apart from not crashing on those UT that reach 2^32 on 32-bit systems)